### PR TITLE
feat: proxy_router upload input image 저장기능 및 기초 구조 설정

### DIFF
--- a/back/routes/embedding.py
+++ b/back/routes/embedding.py
@@ -1,0 +1,31 @@
+'''
+proxy server의 역할
+1) embedding server에 embedding 요청 -> embedding model과 client 요청 필요
+2) search server(faiss)에 search 요청 -> embedding model과 client 요청 필요
+3) meta_db에 search 요청 -> 몽고db연결 -> connection.py 작성
+'''
+
+from fastapi import APIRouter, File, UploadFile
+import uuid
+import os
+import httpx
+
+proxy_router = APIRouter(
+    tags=["Proxy"],
+)
+
+@proxy_router.post("/search-by-image")
+async def search_by_image(file: UploadFile) -> dict:
+    # -- input_image를 storage/queries 저장
+    UPLOAD_DIR = "storage/queries"
+    
+    content = await file.read()
+    rid = str(uuid.uuid4())
+    filname = f"{rid}.png" # --uuid로 유니크한 파일명으로 변경(중복방지)
+    with open(os.path.join(UPLOAD_DIR, filname), "wb") as fp:
+        fp.write(content) # -- 서버 로컬스토리지에 이미지 저장
+        
+    
+    return {
+        "msg": "OK"
+    }


### PR DESCRIPTION
## Background
- proxy server에서 해야할 일 첫 번째는 input_image를 받으면 우선 로컬 스토리지에 저장합니다.
-  fashion clip에서 image_path를 필요로 하기 때문에 embedding 모델에 넣기 위해서 저장할 필요가 있습니다.

## Works
-  `back/proxy.py`
    - UploadFile로 이미지 업로드 기능 구현
    - uuid로 유니크한 파일명 설정 후 storage/queriesr에 저장

## See Also
- comment 반영