### PR TITLE
feat: fashion-clip embedding model 구현

### DIFF
--- a/back/infra/embedding/model.py
+++ b/back/infra/embedding/model.py
@@ -1,0 +1,17 @@
+from fashion_clip.fashion_clip import FashionCLIP
+import numpy as np
+import os
+
+class EmbeddingModel:
+    IMG_PATH = "storage/queries"
+    
+    def __init__(self) -> None:
+        self.flip = FashionCLIP("fashion-clip")
+        
+    
+    def get_embedding(self, rid: str) -> list[float]:
+        filename = f"{rid}.png"
+        
+        img_path = os.path.join(self.IMG_PATH, filename)
+        embedding = self.flip.encode_images([img_path], batch_size=1).flatten() # (1, 512) -> flatten -> (512,)
+        return embedding.tolist()


### PR DESCRIPTION
## Background
- embedding server에 올릴 embedding model 작성했습니다. embedding model은 embedding server 내부에서 돌아가므로 추후 embedding_router에서 사용하게 될 예정입니다.

## Works
-  `infra/embedding/embedding.py`
    - EmbeddingModel 클래스 생성

## See Also
- fashion-clip에서 현재는 embedding시 image_path가 리스트에 저장되어있도록 되어있습니다. image 파일만 들어가도 embedding이 될 수 있도록 추후 수정해야합니다.