### PR TITLE
feat: embedding router추가

### DIFF
--- a/back/routes/embedding.py
+++ b/back/routes/embedding.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+from infra.embedding.model import EmbeddingModel
+
+embedding_router = APIRouter(
+    tags=["Embedding"]
+)
+
+model = EmbeddingModel()
+
+@embedding_router.get("/{rid}")
+async def get_embedding(rid: str) -> dict:
+    print("rid는 여기다!:", rid)
+    embedding = model.get_embedding(rid)
+    return {
+        "msg": "OK!",
+        "embedding": embedding
+    }
+


### PR DESCRIPTION
## Background
- infra에 만든 embedding model의 get_embedding 은 embedding_router에서 사용됩니다. 임베딩 서버는 input_image에 대해 EmbeddingModel에서 embedding을 만드는 기능을 수행하게 됩니다. embedding server는 추후 client가 요청을 할 시에 embedding 값을 response로 출력합니다.

## Works
-  `routes/embedding.py`
    - get_embedding() 추가

## See Also
