### PR TITLE
feat: EmbeddingClient

### DIFF
--- a/back/infra/embedding/client.py
+++ b/back/infra/embedding/client.py
@@ -1,0 +1,15 @@
+import httpx
+
+# --embedding server에 embedding 요청
+class EmbeddingClient:
+    # --embedding server api
+    API_URL = "http://localhost:9000/embedding"
+    
+    async def get_embedding(self, rid):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self.API_URL}/{rid}",
+            )
+            
+            embedding = response.json()["embedding"]
+            return embedding


### PR DESCRIPTION
## Background
- infra애 요청을 날려줄 client를 만들어야 합니다. client는 embedding server에 httpx를 통해서 api를 호출해서 embedding한 결과값을 response로 받아옵니다.
- 
## Works
-  `infra/  embedding/client.py`
    - EmbeddingClient 구현

## See Also
- 아직 서버를 돌려서 직접 테스트는 하지 못했습니다. 따라서 문제가 발생할 수도 있습니다.