### PR TITLE
feat: add proxy, embedding server router

### DIFF
--- a/back/embedding.py
+++ b/back/embedding.py
@@ -3,7 +3,8 @@ import uvicorn
 
 app = FastAPI()
 
-# app.include_router(router=, prefix=)
+from routes.embedding import embedding_router
+app.include_router(embedding_router, prefix="/embedding")
 
 @app.get("/")
 async def servercheck() -> dict:

--- a/back/proxy.py
+++ b/back/proxy.py
@@ -3,7 +3,9 @@ import uvicorn
 
 app = FastAPI()
 
-# app.include_router(router=, prefix=)
+from routes.proxy import proxy_router
+
+app.include_router(proxy_router, prefix="/proxy")
 
 @app.get("/")
 async def servercheck() -> dict:


### PR DESCRIPTION
## Background
- proxy server와 embedding server에 라우터를 추가했습니다.  라우터들을 통해서 파악하고자하는 바는 다음과 같습니다.
    - proxy server는 우선 queries에 input_image가 저장되는지 확인해야했고 proxy server에 쿼리를 날렸을 때 {"msg": "OK!"}가 떠서 잘 저장되고 실제 storage도 저장된 것을 확인했습니다.
    - embedding server에 쿼리를 날렸을 때 잘 작동하는 것을 확인했습니다. 000.png가 아니라 uuid의해서 임의의 숫자로 filename을 변경한 것을 잠깐 착각하여 rid를 000으로 넣어 잠깐의 오류가 발생했었습니다.
## Works
-  `embedding.py`
    - embedding_router 추가
-  'proxy.py`
    - proxy_router 추가

## See Also
- 작성하는 현재, 서버를 쓸 수가 없어 문제가 발생할 수 있습니다. 서버 연결되고 테스트 후에 문제발생한 부분을 예외처리하는 등의 수정이 필요할 것입니다. -> proxy server와 embedding server 모두 잘 작동하는 것을 확인했습니다.