### PR TITLE
feat: add search_serve proxy_server is ok

### DIFF
--- a/back/infra/search/client.py
+++ b/back/infra/search/client.py
@@ -1,0 +1,24 @@
+import httpx
+
+# --search server에 search 요청
+class SearchClient:
+    ## -- search server api url
+    API_URL = "http://localhost:9001/search"
+    print("여기 밑으로 못 내려가는건가?")
+    async def search(self, embedding: list[float]) -> (list[float], list[int]):
+        async with httpx.AsyncClient() as client:
+            print("여기는 들어왔나?")
+            response = await client.post(
+                f"{self.API_URL}",
+                json={
+                    "embedding": embedding
+                    },
+                timeout=None
+            )
+        
+            print("response의 Status_code는 여기에 있다!", response.status_code)
+            
+            dists = response.json()["dists"]
+            ids = response.json()["ids"]
+        
+        return dists, ids

--- a/back/infra/search/model.py
+++ b/back/infra/search/model.py
@@ -1,0 +1,41 @@
+import faiss
+import os
+import numpy as np
+import pickle
+
+'''
+faiss 사용법 참고 : 2단계에 걸쳐서 진행, 변수는 웬만해서는 np.array로 들어간다.
+1) output_embeddings에 id 부여 (현재는 output_embeddigs를 pkl로 저장함)
+index.add_with_ids(output_embs, ids) -> 각 임베딩과 id를 매칭시켜주는 작업
+2) 입력으로 들어온 input_embedding과 유사도 검색
+result = index.search(input_emb.reshape(1, -1), 2) <- input_emb: np.array
+(array([[94.22209, 89.08495]], dtype=float32), array([[32, 34]]))
+'''
+
+class SearchModel:
+    DATA_PATH = 'storage/embedding'
+    
+    
+    def __init__(self):
+        index = faiss.IndexFlatIP(512) #--embedding의 차원 수,
+        self.index = faiss.IndexIDMap2(index) # --embedding에 id를 부여하기위해서
+    
+        ids = []
+        embs = []
+        for filename in os.listdir(self.DATA_PATH):
+            id = filename.split(".")[0] # 000.pkl
+            ids.append(id)
+            with open(os.path.join(self.DATA_PATH, filename), "rb") as f:
+                emb = pickle.load(f)
+                embs.append(emb)
+        self.index.add_with_ids(np.array(embs), np.array(ids))
+        
+        
+    def search(self, embedding: list[float]) -> (list[float], list[int]):
+        dists, ids = self.index.search(np.array(embedding).reshape(1, -1), 2)
+        print("dists.dtype은 여기에 있다!", dists.dtype)
+        return dists.flatten().tolist(), ids.flatten().tolist()
+        
+        
+        
+        

--- a/back/models/search.py
+++ b/back/models/search.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class ImgEmbedding(BaseModel):
+    
+    embedding: list[float]

--- a/back/routes/proxy.py
+++ b/back/routes/proxy.py
@@ -11,12 +11,14 @@ import os
 import httpx
 
 from infra.embedding.client import EmbeddingClient
+from infra.search.client import SearchClient
 
 proxy_router = APIRouter(
     tags=["Proxy"],
 )
 
 embedding_client = EmbeddingClient()
+search_client = SearchClient()
 
 @proxy_router.post("/search-by-image")
 async def search_by_image(file: UploadFile) -> dict:
@@ -31,7 +33,11 @@ async def search_by_image(file: UploadFile) -> dict:
         
     embedding = await embedding_client.get_embedding(rid)
     
+    dists, ids = await search_client.search(embedding)
+    
     return {
         "msg": "OK",
-        "embedding": embedding
+        "embedding": embedding,
+        "dists": dists,
+        "ids": ids
     }

--- a/back/routes/search.py
+++ b/back/routes/search.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+
+from infra.search.model import SearchModel
+from models.search import ImgEmbedding
+
+search_router = APIRouter(
+    tags=["Search"],
+)
+
+model = SearchModel()
+
+# -- get을 써야해, post를 써야해?
+@search_router.post("")
+async def search(Imgembedding: ImgEmbedding) -> dict:
+    
+    dists, ids = model.search(Imgembedding.embedding)
+    
+    return {
+        "msg": "Search OK!",
+        "dists": dists,
+        "ids": ids,
+    }

--- a/back/search.py
+++ b/back/search.py
@@ -3,7 +3,9 @@ import uvicorn
 
 app = FastAPI()
 
-# app.include_router(router=, prefix=)
+from routes.search import search_router
+
+app.include_router(search_router, prefix="/search")
 
 @app.get("/")
 async def servercheck() -> dict:


### PR DESCRIPTION
## Background 
- 지금부터는 깃관리 방식을 rebase가 아닌 merge로 연습을 할 것입니다.  search, proxy, embedding branch를 미리 만들고 이 세가지 branch를 관리하면서 깃을 다룰 것 입니다.
---
- search branch에서는 embedding이 proxy에 잘 전달되고 출력이 되는 것을 확인했으므로 이 embedding을 search server에서 dists, ids얻어낼 수 있게 하면 우선 1차적으로 기획한 backend의 기능은 끝이 나게 됩니다.
      
## Works
- main에 merge된 search branch에서는 다음과 같은 것을 기능들이 구현되었습니다.
    - `infra/search/model.py`
        - Faiss를 활용해 SearhMoedl 클래스를 구현했습니다. IndexFlatIP은 BruteForce & IP로 유사도 검색을 합니다. 현재는 storage에 존재하는 output_image의 embedding을 pkl로 저장된 상태로 filename을 가지고 embedding.pkl과 연동시켜 id를 부여합니다. 
        - search 메서드를 Faiss의 search 메서드를 활용해서 구현했습니다.
        - Faiss를 다룰 때 주의해야할 점은 input과 output 파라메타가 대부분 np.array로 들어갑니다. 우리가 embedding을 list[float] 타입으로 받고 있기 때문에 search 사용할 때 np.array로 변경해줘야합니다. return값도 np.array 타입을 갖기 때문에 반복가능한(iterable)이 아니기 때문에 search_router의 return 값인 dict에 value 값을 확인할 때 에러가 발생하므로 `.tolist()`가 필요합니다.
        -  `.tolist()`만 하면 np.array의 차원이 그대로 오는 문제가 발생하여 사실 1차원을 기대하고 있는데 np.array의 차원이 나와버려서 이를 해결하기 위해서 `flatten()`을 이용해서 차원을 낮춰야 원하는 모양이 출력이 됩니다.
    - `routes/search.py`
        - SearchModel을 통해서 search_router를 구현합니다. searh_router는 `models/search.py`에서 pydantic을 활용해서 요청바디를 작성했습니다.
        - 이 부분에서 가장 큰 고민이 있었는데 **get**을 써야하는가? **post**를 써야하는가?에 대한 고민이 있었다. 처음에는 get를 사용했고 쿼리를 날렸을 때 search_server는 잘 작동하는 것을 확인했습니다.
    - `infra/search/client.py`
         - 분명 search_server가 잘 작동했는데 clinet가 요청했을 때는 response의 상태코드가 4xx가 떴다. httpx가 요청을 보냈는데 잘 되지 않아서  
         - 중간에 오타와 같은 자잘한 실수가 있긴 했지만 아무리 해도 에러가 고쳐지지는 않았습니다. search_server는 분명 잘 작동되는 것을 확인했는데 왜 에러가 나는지 찾기가 정말 어려웠는데 그런데 구글링 결과 다음과 같은 글이 있었습니다.
         - [[HTTP] 왜 GET은 body를 안쓸까?](https://velog.io/@sejin3319/HTTP-HTTP-Method)
         - [[JSP] HTTP 요청 메서드(GET과 POST)(자막있음)](https://youtu.be/aCSryu_emlA)
         - **get은 요청바디를 잘 안쓴다고 합니다**..잘 몰랐는데;;;; Post로 바꿨을 때 server client가 보낸 요청을 잘 처리해서 response가 잘 전달되어 proxy_server가 ids, dists를 잘 출력하는 것을 확인했습니다.

## See Also
- 