### PR TITLE
feat: make front by gradio

### DIFF
--- a/front/main.py
+++ b/front/main.py
@@ -1,0 +1,32 @@
+import gradio as gr
+from PIL import Image
+import os
+import httpx
+import io 
+
+def image_mod(image: Image):
+    image_bytes = io.BytesIO()
+
+    image.save(image_bytes, format='PNG')
+    image_bytes = image_bytes.getvalue()
+    files = {"file": image_bytes}
+    response = httpx.post("http://localhost:8000/proxy/search-by-image", files=files, timeout=None)
+    ids = response.json()["ids"]
+    output_path = f"../test/output/{ids[0]:03}.jpeg"
+    output_image = Image.open(output_path)
+    return output_image
+
+demo = gr.Interface(
+    fn=image_mod,
+    inputs=gr.Image(type="pil"),
+    outputs="image",
+    examples=[
+        "../test/input/000.png",
+        "../test/input/001.png",
+        "../test/input/003.png",
+        "../test/input/004.png",
+    ],
+)
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Background 
- image를 받아서 Fashion-CLIP으로 임베딩한 결과값을 바탕으로 ids, dists를 얻어내는 과정을 마친 후 이제 이를 보여줘야하므로 프론트 영역에서 결과값을 받아서 보여주면 됩니다. 프론트에 사용할 라이브러리는 [gradio](https://gradio.app/docs/)로 웹데모를 만들 때 상당히 간단하다고 알게 되어서 진짜 간단하게만 사용해 적당히 공식문서와 블로그 참고하여 30분정도 할애했습니다.
      
## Works
- `front/main.py`: gradio 활용하여 간단 웹 데모 구현

## See Also
- 간단한 1차 웹 데모를 만들어서 다음과 같은 점을 보완 및 추가 해야합니다.
      - Example 이미지가 깨진 점
      - output_image의 사이즈가 너무 크다는 점
      - 추후 Textbox에 color라는 input을 하나 더 집어 넣을 수 있는지
      - 현재는 1개의 이미지만 보여주는데 10개정도의 이미지도 보여줄 수 있는 방법이 있는지 
#### 참고
- [Gradio - Python으로 머신러닝 모델 웹 앱 배포하기](https://wooiljeong.github.io/etc/intro-gradio/)