### PR TITLE
feat: add text embedding model, router, client

### DIFF
--- a/back/infra/embedding/client.py
+++ b/back/infra/embedding/client.py
@@ -5,12 +5,26 @@ class EmbeddingClient:
     # --embedding server api
     API_URL = "http://localhost:9000/embedding"
     
-    async def get_embedding(self, rid):
+    async def get_image_embedding(self, rid):
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                f"{self.API_URL}/{rid}",
+                f"{self.API_URL}/image/{rid}",
                 timeout=None
             )
             
             embedding = response.json()["embedding"]
             return embedding
+        
+    
+    async def get_text_embedding(self, text: str):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self.API_URL}/text",
+                timeout=None,
+                json = {
+                    "text": text,
+                }
+            )
+            
+            embedding = response.json()["embedding"]
+            return embedding            

--- a/back/infra/embedding/model.py
+++ b/back/infra/embedding/model.py
@@ -9,9 +9,16 @@ class EmbeddingModel:
         self.flip = FashionCLIP("fashion-clip")
         
     
-    def get_embedding(self, rid: str) -> list[float]:
+    def get_image_embedding(self, rid: str) -> list[float]:
         filename = f"{rid}.png"
         
         img_path = os.path.join(self.IMG_PATH, filename)
         embedding = self.flip.encode_images([img_path], batch_size=1).flatten() # (1, 512) -> flatten -> (512,)
+        embedding /= np.linalg.norm(embedding) # 정규화
+        return embedding.tolist()
+    
+    
+    def get_text_embedding(self, text: str) -> list[float]:
+        embedding = self.flip.encode_text([text], batch_size=1).flatten() #(1, 512) -> flatten -> (512,)
+        embedding /= np.linalg.norm(embedding) # 정규화
         return embedding.tolist()

--- a/back/models/embedding.py
+++ b/back/models/embedding.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class Text(BaseModel):
+    text: str

--- a/back/routes/embedding.py
+++ b/back/routes/embedding.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
+
 from infra.embedding.model import EmbeddingModel
+from models.embedding import Text
 
 embedding_router = APIRouter(
     tags=["Embedding"]
@@ -7,10 +9,20 @@ embedding_router = APIRouter(
 
 model = EmbeddingModel()
 
-@embedding_router.get("/{rid}")
-async def get_embedding(rid: str) -> dict:
+@embedding_router.get("/image/{rid}")
+async def get_image_embedding(rid: str) -> dict:
     print("rid는 여기다!:", rid)
-    embedding = model.get_embedding(rid)
+    embedding = model.get_image_embedding(rid)
+    return {
+        "msg": "OK!",
+        "embedding": embedding
+    }
+    
+# url에 query x => post => 요청바디 필요
+@embedding_router.post("/text")
+async def get_image_embedding(text: Text) -> dict:
+    print("내가 넣은 text는 여기다!:", text.text)
+    embedding = model.get_text_embedding(text.text)
     return {
         "msg": "OK!",
         "embedding": embedding


### PR DESCRIPTION
## Background 
- merge로 깃 관리 시작! 따라서 embedding, search, proxy, front 4개의 브랜치만 활용하여 깃 관리할 것입니다.  이제 main에 merge될 것들은 세세한 기능이 아닌 embedding, search, proxy, front처럼 굵직한 기능들입니다.
- Text를 활용할 수 있도록 Text Embedding API를 구현할 필요가 있었습니다. 
---
## TODO
- 1) infra.embedding.model의 EmbeddingModel에 text embedding 추출 구현
- 2) router.embedding에 text embedding router 구현
- 3) infra.embedding.client에서 embedding server에 text embedding 요청시 embedding 되는지 확인하기
      
## Works
- main에 merge된 embedding branch에서는 다음과 같은 것을 기능들이 구현되었습니다.
    - `infra/embedding/model.py`
        - Fashion-clip에서 encode_text를 통해서 get_text_embedding 메서드 구현했습니다. 기존에 EmbeddingModel 클래스는 image만을 입력으로 받아서 메서드명을 get_embedding 단순하게 기입했는데 image와 text를 구별하기 위해서 get_image_embedding과 get_text_embedding으로 메서드명을 설정했습니다.
    - `router/embedding.py`
        - EmbeddingModel을 완성한 후 기존의 embedding router에도 변경사항이 있었습니다. 첫 번째로는 메서드명(get_embedding > get_image_embedding)을 변경했고 두 번째는 text embedding과 관련한 router를 추가했습니다.
        - 항상 get과 post에서 고민을 많이합니다. image router와 달리 text router는 url에 text를 노출하지 않을 것이기 때문에 post 메서드를 활용했고 post 메서드를 사용해야하기 때문에 요청 바디(Request Body를 설정해야했습니다.
     - `models/embedding.py`
         - pydantic의 BaseModel을 상속받아서 Text 클래스를 생성하고 **text: str** 설정합니다. 우선 지금은TypeHint를 str을 강제하고 있는 상황인데 구현하려는 기능에 따라서 **Optional, None 등을 활용할 수 있을 것 같다는 생각이 듭니다.**
   - `infra/embedding/client.py` 
       - 지금까지 한 것을 요약하면 EmbeddingModel에 text_embedding 메서드를 구현했고 이를 이용해서 text router를 추가했습니다. 그런데 text router는 image router와 달리 post 메서드를 활용해야해서 요청바디를 설정해야했습니다.
       - 따라서 `infra/embedding/client.py` 에서는  text를 요청바디(json형식)에 넣어 embedding server에  요청했을 때 response를 받도록 구현했습니다.  
       - get 과 달리 **post에서 요청할 때 요청바디 쓰는 것 잊지 말기!**
       - Postman 에서 쿼리 날렸을 때 text embedding 확인!!
      ```
      {
        "text": "COMME-DES-GARCONS"
      }
      {
          "msg": "OK!",
          "embedding": [
              0.006259332410991192,
              -0.005979645997285843,
              -0.08830244839191437,
              -0.01256292313337326,
              -0.0034259690437465906,...}
    ```
## See Also
- 