### PR TITLE
feat: text, image, text+image  search ok!

### DIFF
--- a/back/infra/search/client.py
+++ b/back/infra/search/client.py
@@ -5,19 +5,44 @@ class SearchClient:
     ## -- search server api url
     API_URL = "http://localhost:9001/search"
     print("여기 밑으로 못 내려가는건가?")
-    async def search(self, embedding: list[float]) -> (list[float], list[int]):
+    
+    
+    async def search(self, embedding: list[float], thresh: float) -> (list[float], list[int]):
         async with httpx.AsyncClient() as client:
-            print("여기는 들어왔나?")
+            print("단일한 embedding 요청 들어왔나?")
             response = await client.post(
                 f"{self.API_URL}",
                 json={
-                    "embedding": embedding
+                    "thresh": thresh,
+                    "embedding": embedding,
                     },
                 timeout=None
             )
         
-            print("response의 Status_code는 여기에 있다!", response.status_code)
+            print("단일 embedding의 response의 Status_code는 여기에 있다!", response.status_code)
             
+            dists = response.json()["dists"]
+            ids = response.json()["ids"]
+        
+        return dists, ids
+    
+    
+    async def search_with_filter(self, embedding: list[float], filter_embedding: list[float], thresh: float) -> (list[float], list[int]):
+        print("여기는 client의 search_with_filter야! 잘 들어왔는지 확인하는 곳임@-@!")
+        async with httpx.AsyncClient() as client:
+            print("embedding들 요청 들어왔나?")
+            response = await client.post(
+                f"{self.API_URL}/with-filter",
+                json={
+                    "thresh": thresh,
+                    "embedding": embedding,
+                    "filter_embedding": filter_embedding,
+                },
+                timeout=None
+            )
+            
+            print("embedding들의 response의 Status_code는 여기에 있다!", response.status_code)
+
             dists = response.json()["dists"]
             ids = response.json()["ids"]
         

--- a/back/infra/search/utils.py
+++ b/back/infra/search/utils.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+# Good -> 2순위
+def L2norm(a: np.ndarray, b=0):
+    return np.linalg.norm(a - b)
+
+# Good -> 1순위
+def cos_sim(a: np.ndarray, b: np.ndarray):
+    a = a.astype(np.float64)
+    b = b.astype(np.float64)
+    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+# Good
+def pearson_sim(a: np.ndarray, b: np.ndarray):
+    a = a.astype(np.float64)
+    b = b.astype(np.float64)
+    return np.dot((a - np.mean(a)), (b - np.mean(b))) / ((np.linalg.norm(a - np.mean(a))) * (np.linalg.norm(b - np.mean(b))))
+
+# Bad
+def jaccard_sim(a: np.ndarray, b: np.ndarray):
+    intersection = np.intersect1d(a, b)
+    union = np.union1d(a, b)
+    similarity = len(intersection) / len(union)
+    return similarity
+
+# Bad
+def covariance(a, b):
+    return np.cov(a, b, ddof=1)

--- a/back/models/search.py
+++ b/back/models/search.py
@@ -1,6 +1,14 @@
 from pydantic import BaseModel
 
 
-class ImgEmbedding(BaseModel):
+class SearchParm(BaseModel):
     
     embedding: list[float]
+    thresh: float
+    
+
+class SearchWithFilterParam(BaseModel):
+    
+    embedding: list[float]
+    filter_embedding: list[float]
+    thresh: float

--- a/jupyternotebook/iter_test.ipynb
+++ b/jupyternotebook/iter_test.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# np.array에서 for문이 효율적인가?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import time"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 체크1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "# ids = np.array(list(range(9)))\n",
+    "# thresh = 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "22 ms ± 342 µs per loop (mean ± std. dev. of 10 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 100 -r 10\n",
+    "# dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "# ids = np.array(list(range(9)))\n",
+    "# thresh = 0.001\n",
+    "dists = np.random.rand(100000)\n",
+    "ids = np.array(list(range(100000)))\n",
+    "thresh = 0.0\n",
+    "for idx, dist in enumerate(dists):\n",
+    "    if dist <= thresh:\n",
+    "        dist = dist[:idx]\n",
+    "        ids = ids[:idx]\n",
+    "        break\n",
+    "dists.flatten().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10.8 ms ± 110 µs per loop (mean ± std. dev. of 10 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 100 -r 10\n",
+    "# dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "# ids = np.array(list(range(9)))\n",
+    "# thresh = 0.001\n",
+    "dists = np.random.rand(100000)\n",
+    "ids = np.array(list(range(100000)))\n",
+    "thresh = 0.0\n",
+    "indices = np.where(dists >= thresh)[0]\n",
+    "dists = dists[:len(indices)]\n",
+    "ids = ids[:len(indices)]\n",
+    "\n",
+    "dists.flatten().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "11.1 ms ± 175 µs per loop (mean ± std. dev. of 10 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 100 -r 10\n",
+    "# dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "# ids = np.array(list(range(9)))\n",
+    "# thresh = 0.001\n",
+    "dists = np.random.rand(100000)\n",
+    "ids = np.array(list(range(100000)))\n",
+    "thresh = 0.0\n",
+    "indices = np.where(dists >= thresh)[0]\n",
+    "k = len(indices)\n",
+    "dists = dists[:k]\n",
+    "ids = ids[:k]\n",
+    "\n",
+    "dists.flatten().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "36 ms ± 1.02 ms per loop (mean ± std. dev. of 10 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 100 -r 10\n",
+    "# dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "# ids = np.array(list(range(9)))\n",
+    "# thresh = 0.001\n",
+    "dists = np.random.rand(100000)\n",
+    "ids = np.array(list(range(100000)))\n",
+    "thresh = 0.0\n",
+    "it = np.nditer(dists, flags=['c_index'])\n",
+    "while not it.finished:\n",
+    "    idx = it.index\n",
+    "    if dists[idx] <= thresh:\n",
+    "        break\n",
+    "    it.iternext()\n",
+    "dists = dists[:idx]\n",
+    "ids = ids[:idx]\n",
+    "\n",
+    "dists.flatten().tolist()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 체크2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def array_time_check(thresh: float, iter_mode: int):\n",
+    "    # --faiss의 결과물이므로 자동으로 dists는 \"가끼운 순으로 정렬\"된다.\n",
+    "    dists = np.array([0.1234, 0.43534, 0.4545, 0.12398, 0.7789, 0.6583, 0.5563, 0.33423, 0.832423,])\n",
+    "    ids = np.array(list(range(9)))\n",
+    "    \n",
+    "    start_time = time.perf_counter()\n",
+    "\n",
+    "    if iter_mode == 1:\n",
+    "        for idx, dist in enumerate(dists):\n",
+    "            if dist <= thresh:\n",
+    "                dist = dist[:idx]\n",
+    "                ids = ids[:idx]\n",
+    "                break\n",
+    "    elif iter_mode == 2:\n",
+    "        indices = np.where(dists >= thresh)[0]\n",
+    "        dists = dists[:len(indices)]\n",
+    "        ids = ids[:len(indices)]\n",
+    "    else:\n",
+    "        it = np.nditer(dists, flags=['c_index'])\n",
+    "        while not it.finished:\n",
+    "            idx = it.index\n",
+    "            if dists[idx] <= thresh:\n",
+    "                break\n",
+    "            it.iternext()\n",
+    "        dists = dists[:idx]\n",
+    "        ids = ids[:idx]\n",
+    "        \n",
+    "    dists.flatten().tolist(), ids.flatten().tolist()\n",
+    "    \n",
+    "    end_time = time.perf_counter()\n",
+    "    \n",
+    "    return f\"실행 시간_time이 함수 안에 있을 때: {end_time - start_time:.5f}초: {iter_mode},\\n{dists},\\n{ids}\"\n",
+    "\n",
+    "start_time = time.perf_counter()\n",
+    "\n",
+    "print(array_time_check(0.01, 1))\n",
+    "\n",
+    "end_time = time.perf_counter()\n",
+    "\n",
+    "print(f\"실행 시간: {end_time - start_time:.5f}초, for사용\")\n",
+    "\n",
+    "print(\"-\" * 80)\n",
+    "\n",
+    "start_time = time.perf_counter()\n",
+    "\n",
+    "print(array_time_check(0.01, 2))\n",
+    "\n",
+    "end_time = time.perf_counter()\n",
+    "\n",
+    "print(f\"실행 시간: {end_time - start_time:.5f}초, where사용\")\n",
+    "\n",
+    "print(\"-\" * 80)\n",
+    "\n",
+    "start_time = time.perf_counter()\n",
+    "\n",
+    "print(array_time_check(0.01, 3))\n",
+    "\n",
+    "end_time = time.perf_counter()\n",
+    "\n",
+    "print(f\"실행 시간: {end_time - start_time:.5f}초, iter사용\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1, 10)\n",
+      "[[0.49652797037415364, 0.5688486949011543, 0.3534625928447229, 0.21231535865548912, 0.3835059781620266, 0.7413077356656254, 0.31619987147365525, 0.31173874513363653, 0.9703179855055901, 0.5290041201080805]]\n",
+      "[0.49652797 0.56884869 0.35346259 0.21231536 0.38350598 0.74130774\n",
+      " 0.31619987 0.31173875 0.97031799 0.52900412]\n",
+      "[0.49652797037415364, 0.5688486949011543, 0.3534625928447229, 0.21231535865548912, 0.3835059781620266, 0.7413077356656254, 0.31619987147365525, 0.31173874513363653, 0.9703179855055901, 0.5290041201080805]\n"
+     ]
+    }
+   ],
+   "source": [
+    "arr = np.random.rand(1, 10)\n",
+    "print(arr.shape)\n",
+    "print(arr.tolist())\n",
+    "print(arr.flatten())\n",
+    "print(arr.flatten().tolist())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Background 
- 바로 전 text embedding을 할 수 있도록 EmbeddingModel를 수정했었습니다. embedding router에는 text embedding 추출을 위한 메서드를 추가했고, 이후  Embedding server에 client가 text or image에 대한 embedding을 요청했을 때 각 input에 대한 embedding이 잘 추출되었으며 , 이는 embedding server와 client 모두가 잘 작동하고 있음을 의미합니다.
- 따라서 text, image embedding값을 모두를  이용해서 Search 할 수 있도록 수정해야합니다.
---
## TODO
- 1) infra.search.model의 SearchModel에 text embedding값 (*이하 filter 로 명명*)이용해서 dists, ids 정렬하기
- 2) router.search에 *filter* 적용한 router 구현
- 3) infra.search.client에서 image embedding + *filter* 를 search embedding 요청바디로 요청했을 때 dists, ids 출력되는지 확인

## Works
- main에 merge된 search branch에서는 다음과 같은 것을 기능들이 구현되었습니다.
    - `infra/search/model.py`, `infra/search/utils.py`
        - text나 image 단일 embedding에 대해서는 기존의 search 메서드를 이용하면 충분합니다. 다만 SearchModel의 기존의 search 메서드에 thresh를 포함시켰습니다. 이 기능을 구현한 이유는 (데이터량이 충분히 많아지면 사라질 문제라고 개인적으로 생각하는데) 현재는 top_k를 10개만 잡아도 정성적으로 판단하기에 관련없는게 포함되는 경우가 있어서 dist가 thresh 이하면 거를 수 있도록 하기 위해서 만들었습니다. thresh는 실험적 값으로 현재는 0.0으로 설정하여 thresh가 작동되지 않도록 했는데 이는 데이터가 충분히 많아지고 나서 실험을 거쳐서 적정한 값을 셜정해야합니다.
        - search_with_filter 메서드를 추가했습니다. 단일한 임베딩만을 입력으로 받는 search 메서드와 다르게 search_with_filter는 text, image embedding을 모두 입력으로 받습니다. 우선적으로 image embedding을 통해서 dists, ids를 얻은 후에 faiss의 reconstruct 기능을 이용해 id를 통해서 기존의 image embedding값을 불러와 text embedding과 con_sim로 정렬(reverse=True)합니다. 
        - 유사도를 판별할 수 있는 함수들은 `utils.py`에 두어 사용했습니다. 
        - np.array 객체인 dists, ids에서 thresh 이하인 값을 찾아내는데 처음 설계에서는 for문을 사용했었는데 np.array에 for문을 사용하지 않고 더 빠르게 처리할 수 있지 않을까라는 생각을 하게 되어 See Also에 정리했습니다.
    - `router/search.py`, `models/search.py`
        - SearchModel의 search 메서드와 search_with_filter 메서드를 이용헤 router를 구현했습니다. post 메서드를 사용해서 구현했으며 post 메서드에 사용될 요청바디 구현했습니다. thresh도 요청바디의 필드로 넣었는데 넣은 이유는 현재는 thresh를 사용자(고객)이 조정하면서 옷의 범위를 더 늘리거나 줄이는 방식을 채택하면 좋지않을까?라는 생각때문입니다. 하지만 보여줄 옷의 개수를 개발자가 설정할 것이라면 필드로 굳이 설정하지는 않아도 될 것 같습니다.
        - SearchModel에서 top_k를 10개로 잡은터라 router에서 `k = 10`으로 설정한게 의미없는 값이 되었습니다만, 일반적으로 top_k > k로 **k는 개발자가 사용자에게 보여줄 옷의 개수를 의미**합니다.
    - `infra/search/client.py` 
        -  client가 단일한 embedding에 대한 요청과 image, text 모두를 넣은 요청하는 코드를 구현했습니다. 단일한 embedding에 대해서는 response(status_code: 200)으로 성공적이었는데 두 가지 embedding을 요청했을 때 internal server error가 났습니다. 
        - internal server error가 나서 에러코드를 봤는데 `faiss::idx_t`의 TypeError 였습니다. 그래서 faiss의 소스 코드를 봤는데  `typedef int64_t faiss_idx_t; ///< all indices are this type`과 같은 것을 발견할 수 있었습니다. ids의 id의 type도 int형일텐데 왜 안될까라는 생각을 했는데 np.array int64가 아닌 구글링 결과 파이썬의 int자료형을 요구하는 것이었고 `tolist()`로 변경을 해서  TypeError는 해결되었습니다. 그런데 또 하나의 문제가 발생했는데 dists, ids의 shape이 (1, top_k) 로 `flatten()`을 하지 않아서 문제가 발생한 것이었고 `flatten()`을 진행해 2차원을 1차원데이터로 적절하게 수정해 response가 성공적으로 도착했습니다.
    - `jupyternotebook/iter_test.ipynb`
         - np.array에서 for문이 효율적인가라는 의문에 대한 실험
      
## See Also
- np.array에서 for문이 효율적인가? 
    - [numpy array를 사용할 때 for문을 피해야하는 이유](https://hyeonchan523.tistory.com/13) 
    - [python NumPy만을 위한 반복문 iter (loop)](https://rphabet.github.io/posts/python_numpy_loop/)
    - `jupyternotebook/iter_test.ipynb` 에서 실험