### PR TITLE
feat: text, image, text+image proxy server is ok!

### DIFF
--- a/back/embedding.py
+++ b/back/embedding.py
@@ -4,6 +4,7 @@ import uvicorn
 app = FastAPI()
 
 from routes.embedding import embedding_router
+
 app.include_router(embedding_router, prefix="/embedding")
 
 @app.get("/")

--- a/back/infra/embedding/client.py
+++ b/back/infra/embedding/client.py
@@ -1,4 +1,5 @@
 import httpx
+from fastapi import HTTPException, status
 
 # --embedding server에 embedding 요청
 class EmbeddingClient:
@@ -18,13 +19,19 @@ class EmbeddingClient:
     
     async def get_text_embedding(self, text: str):
         async with httpx.AsyncClient() as client:
-            response = await client.get(
+            response = await client.post(
                 f"{self.API_URL}/text",
                 timeout=None,
                 json = {
                     "text": text,
                 }
             )
+            
+            if response.status_code != 200:
+                raise HTTPException(
+                    status_code=response.status_code,
+                    detail="text embedding client error!"
+                )
             
             embedding = response.json()["embedding"]
             return embedding            

--- a/back/infra/search/client.py
+++ b/back/infra/search/client.py
@@ -7,7 +7,7 @@ class SearchClient:
     print("여기 밑으로 못 내려가는건가?")
     
     
-    async def search(self, embedding: list[float], thresh: float) -> (list[float], list[int]):
+    async def search(self, embedding: list[float], thresh: float) -> tuple[list[float], list[int]]:
         async with httpx.AsyncClient() as client:
             print("단일한 embedding 요청 들어왔나?")
             response = await client.post(
@@ -27,7 +27,7 @@ class SearchClient:
         return dists, ids
     
     
-    async def search_with_filter(self, embedding: list[float], filter_embedding: list[float], thresh: float) -> (list[float], list[int]):
+    async def search_with_filter(self, embedding: list[float], filter_embedding: list[float], thresh: float) -> tuple[list[float], list[int]]:
         print("여기는 client의 search_with_filter야! 잘 들어왔는지 확인하는 곳임@-@!")
         async with httpx.AsyncClient() as client:
             print("embedding들 요청 들어왔나?")

--- a/back/infra/search/model.py
+++ b/back/infra/search/model.py
@@ -34,7 +34,7 @@ class SearchModel:
         self.index.add_with_ids(np.array(embs), np.array(ids))
         
         
-    def search(self, embedding: list[float], thresh: float) -> (list[float], list[int]):
+    def search(self, embedding: list[float], thresh: float) -> tuple[list[float], list[int]]:
         dists, ids = self.index.search(np.array(embedding).reshape(1, -1), 10)
         print("잘 되지?", "여기는 search!")
         
@@ -46,7 +46,7 @@ class SearchModel:
         return dists.flatten().tolist(), ids.flatten().tolist()
         
         
-    def search_order_by_filter(self, embedding: list[float], filter_embedding: list[float], thresh: float) -> (list[float], list[int]):
+    def search_order_by_filter(self, embedding: list[float], filter_embedding: list[float], thresh: float) -> tuple[list[float], list[int]]:
         dists, ids = self.index.search(np.array(embedding).reshape(1, -1), 10)
         print("잘 되지?", "여기는 search_order_by_filter야!")
         

--- a/back/models/proxy.py
+++ b/back/models/proxy.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from fastapi import UploadFile
+
+
+class ImageP(BaseModel):
+    
+    file: UploadFile
+    thresh: float
+    
+    
+class TextP(BaseModel):
+    
+    text: str
+    thresh: float
+
+
+class FilterP(BaseModel):
+    
+    file: UploadFile
+    text: str
+    thresh: float

--- a/back/routes/proxy.py
+++ b/back/routes/proxy.py
@@ -5,13 +5,16 @@ proxy server의 역할
 3) meta_db에 search 요청 -> 몽고db연결 -> connection.py 작성
 '''
 
-from fastapi import APIRouter, File, UploadFile
+from typing import Annotated
+from fastapi import APIRouter, UploadFile, Form
 import uuid
 import os
 import httpx
 
 from infra.embedding.client import EmbeddingClient
 from infra.search.client import SearchClient
+
+from models.proxy import ImageP, TextP, FilterP
 
 proxy_router = APIRouter(
     tags=["Proxy"],
@@ -21,9 +24,11 @@ embedding_client = EmbeddingClient()
 search_client = SearchClient()
 
 @proxy_router.post("/search-by-image")
-async def search_by_image(file: UploadFile) -> dict:
+# async def search_by_image(file: UploadFile, thresh: float) -> dict:
+async def search_by_image(file: UploadFile, thresh: Annotated[float, Form()]) -> dict:
     # -- input_image를 storage/queries 저장
     UPLOAD_DIR = "storage/queries"
+    print(f"proxy server 여기까지는 왔니? - 1, thresh - {thresh}")
     
     content = await file.read()
     rid = str(uuid.uuid4())
@@ -31,13 +36,60 @@ async def search_by_image(file: UploadFile) -> dict:
     with open(os.path.join(UPLOAD_DIR, filname), "wb") as fp:
         fp.write(content) # -- 서버 로컬스토리지에 이미지 저장
         
-    embedding = await embedding_client.get_embedding(rid)
+    embedding = await embedding_client.get_image_embedding(rid)
     
-    dists, ids = await search_client.search(embedding)
+    dists, ids = await search_client.search(embedding, thresh)
     
     return {
         "msg": "OK",
         "embedding": embedding,
         "dists": dists,
-        "ids": ids
+        "ids": ids,
+    }
+    
+
+@proxy_router.post("/search-by-text")
+async def search_by_text(textp: TextP)-> dict:
+    print("proxy server 여기까지는 왔니? - 2")
+    
+    text = textp.text
+    thresh = textp.thresh
+    
+    print(text)
+    print(thresh)
+    
+    embedding = await embedding_client.get_text_embedding(text)
+    
+    dists, ids = await search_client.search(embedding, thresh)
+    
+    return {
+        "msg": "OK",
+        "embedding": embedding,
+        "dists": dists,
+        "ids": ids,
+    }
+    
+
+@proxy_router.post("/search-by-filter")
+async def search_by_filter(file: UploadFile, text: Annotated[str, Form()], thresh: Annotated[float, Form()]) -> dict:
+    # -- input_image를 storage/queries 저장
+    UPLOAD_DIR = "storage/queries"
+    
+    content = await file.read()
+    rid = str(uuid.uuid4())
+    filename = f"{rid}.png"
+    with open(os.path.join(UPLOAD_DIR, filename), 'wb') as fp:
+        fp.write(content)
+        
+    embedding = await embedding_client.get_image_embedding(rid)
+    
+    filter_embedding = await embedding_client.get_text_embedding(text)
+    
+    dists, ids = await search_client.search_with_filter(embedding, filter_embedding, thresh)
+    
+    return {
+        "msg": "OK",
+        "embedding": embedding,
+        "dists": dists,
+        "ids": ids,
     }


### PR DESCRIPTION
## Background 
-앞서 Embeddig server, Search server가 잘 작동하는 것을 확인했으니 이제 마지막 마무리로 text, image, text+image(filter) 인풋에 대해서  proxy server에서 dists, ids를 잘 응답하는지 확인하면 back의 대부분은 마무리가 되는 상황입니다.
- 따라서 search-by-text, search-by-image, search-by-filter의 세가지 라우터를 구현할 것입니다.
---
## TODO
- 1) routes.porxy에서 search-by-image에 thresh 추가하기
- 2) routes.proxy에서 search-by-text 구현하기
- 3) routes.proxy에서 search-by-filter 구현하기

## Works
- main에 merge된 proxy branch에서는 다음과 같은 것을 기능들이 구현되었습니다.
    - `infra/search/client.py`, `infra/search/model.py`
        - (list[float], list[int]) 에서 tuple[list[float], list[int]] 로 변경했습니다. 
        - 그 전 타입힌트로도 에러는 없었는데 자료형의 타입을 적어야한다는 글을 보아 변경했습니다.
    - `routes/proxy.py`에서 search-by-text + `infra/embedding/client.py`
        - proxy server에서는  "msg": "field required", "type": "value_error.missing" 에러가 router 전부에서 발생했습니다. 그래서 방법을 2가지를 사용했습니다. ***첫 번째 방법***은 `models/proxy.py`를 만들어 요청바디를 설정했습니다.  `infra/embedding/client.py`에서 get_text_embedding 메서드에서 text 요청바디가 필요함으로 **get**에서 **post**로 변경했습니다. 
    - `routes/proxy.py`에서 search-by-image, search-by-filter
        - ***두 번째 방법***은 `Form()` Data를 활용했습니다. Form Data의 경우 요청바디를 따로 생성하지 않아도 Form 타입힌트를 주면 요청바디의 역할을 하게 됩니다. 특히 Form Data 는 *When you need to receive form fields instead of JSON, you can use Form.* 과 같은 상황에서 유리합니다. `infra/embedding/client.py`에서 get_image_embedding 메서드는 get 메서드를 사용하고 있습니다. 즉 요청바디를 날리지 않는다는 것인데 문제는 사용자가 요청하는 thresh가 존재한다는 것입니다. 즉 UploadFile을 통해서는 get 메서드를 사용하기에 요청바디가 필요없는 상황이고 thresh 사용할 때는 요청바디가 필요한 상황이라고 생각이 됩니다. 그러므로 Form Data로 thresh만 요청으로 지정하면 문제는 해결됩니다.

      
## See Also
- 요청바디 에러에 대한 참고 자료들
    - [Form Data](https://fastapi.tiangolo.com/tutorial/request-forms/)
    - [httpx-QuickStart](https://www.python-httpx.org/quickstart/)
    - 따라서 Work 2가지 방법 중에서 1가지 방법으로 통일할 수 있는지? 확인해보는 작업이 필요해보입니다. 사실 현재는 요청바디를 쓸 정도로 filed가 많이 설정되어 있지 않습니다. 필드의 수가 많아야 2개라서 Form Data를 활용해서 잘 작동하는지 확인을 한 후 리팩토링하는 것도 괜찮을 것 같습니다.

