### PR TITLE
bug: pickle embedding fix

### DIFF
--- a/server/admin/infra/model.py
+++ b/server/admin/infra/model.py
@@ -21,7 +21,7 @@ class DataBase:
         if not os.path.exists(self.SAVE_DIR):
             os.makedirs(self.SAVE_DIR)
         
-        embedding = self.flip.encode_images(paths, batch_size=1).flatten() # (1, 512) -> flatten -> (512,)
+        embedding = self.flip.encode_images(paths, batch_size=1) # (1, 512) -> flatten -> (512,) -> flatten이 문젠가?
         embedding /= np.linalg.norm(embedding) # 정규화
         
         pickles = []

--- a/server/customer/infra/search/model.py
+++ b/server/customer/infra/search/model.py
@@ -21,7 +21,7 @@ class SearchModel:
     def __init__(self, config_path: str):
         with open(config_path) as f:
             self.conf = yaml.safe_load(f)
-        self.DATA_DIR = os.path.join(self.conf["storage"], "embedding") # embedding -> pickle로 수정할 것!
+        self.DATA_DIR = os.path.join(self.conf["storage"], "pickle") # embedding -> pickle로 수정할 것!
         
         index = faiss.IndexFlatIP(512) #--embedding의 차원 수,
         self.index = faiss.IndexIDMap2(index) # --embedding에 id를 부여하기위해서
@@ -34,6 +34,8 @@ class SearchModel:
             with open(os.path.join(self.DATA_DIR, filename), "rb") as f:
                 emb = pickle.load(f)
                 embs.append(emb)
+        print("여기는 id..개수",len(ids))
+        print("여기는 embs..개수",len(embs))
         self.index.add_with_ids(np.array(embs), np.array(ids))
         
         


### PR DESCRIPTION
## Background 
- 5040개의 데이터의 pickle을 사용하여 검색을 진행했습니다. 차원 오류가 발생했었습니다. 이를 확인하기 위해서 노트북에서 정상적으로 작동하는 임베딩 피클과 오류를 내는 피클을 로드해서 보았는데 5040개의 피클을 구할 때 문제가 있었습니다.
---
## Works
-  `server/admin/infra/model.py`
    - `embedding = self.flip.encode_images(paths, batch_size=1).flatten() `에서 `flatten() ` 삭제했습니다. flatte을 한 이유는 input image 1개가 들어왔을 때 (1, 512)으로 임베딩돼 (512,)로 바꿔주기 위함이었습니다. paths로 image들의 path가 한 번에 들어오면 (5040, 512)로 flatten()며 하나의 pickle은 (512,)로 구성되어 있습니다. 따라서 2개 이상의 path가 들어올 때는 embedding시 flatten()을 해서는 안됩니다.
- `server/admin/infra/search/model.py`
    - 이제는 pickle 디렉토리가 피클 관리저장소가 됩니다.

      
## See Also & Error Log
- 