### PR TITLE
feat: customer/proxy server connection db

### DIFF
--- a/server/customer/routes/proxy.py
+++ b/server/customer/routes/proxy.py
@@ -9,13 +9,19 @@ from typing import Annotated
 from fastapi import APIRouter, UploadFile, Form
 import uuid
 import os
-import httpx
+import httpx, time
 
 from infra.embedding.client import EmbeddingClient
 from infra.search.client import SearchClient
 from infra.storage.client import LocalStorageClient
 
 from models.proxy import ImageP, TextP, FilterP
+
+from dotenv import dotenv_values
+from pymongo import MongoClient
+from pprint import pprint
+
+config = dotenv_values("/opt/ml/fashion-image-search/server/admin/.env")
 
 proxy_router = APIRouter(
     tags=["Proxy"],
@@ -24,6 +30,9 @@ proxy_router = APIRouter(
 embedding_client = EmbeddingClient()
 search_client = SearchClient()
 storage_client = LocalStorageClient("queries")
+
+client = MongoClient(config["ATLAS_URI"],connect=False)
+mydb = client[config["DB_NAME"]]
 
 @proxy_router.post("/search-by-image")
 # async def search_by_image(file: UploadFile, thresh: float) -> dict:
@@ -40,6 +49,21 @@ async def search_by_image(file: UploadFile, thresh: Annotated[float, Form()]) ->
     
     dists, ids = await search_client.search(embedding, thresh)
     
+    # fine_one의 Execution time: 3.6651980876922607 seconds > 실제 검색 시 8.37s
+    # find의 Execution time: 0.20023798942565918 seconds
+    # find + ids의 순서로 정렬한 것의 Execution time: 0.20313620567321777 seconds > 실제 검색 시 6.11s
+    # ids의 순서는 곧 유사도의 순위 >find_one이 find보다 18배나 느림 하지만 유사도 순으로 정렬되어있음.
+    # find 후 정렬을 사용하는 것이 find만 사용하는 것보다 0.0003s 차이지만 find_one보다는 압도적 성능을 지닌다.
+    # 빠른 검색이 목적: find / 유사도 정렬이 목적: find_one
+ 
+    collection = mydb["Top"]
+    documents = collection.find({'key': {'$in': ids}})
+    sorted_documents = sorted(documents, key=lambda doc: ids.index(doc['key']))
+
+    for doc in sorted_documents:
+        print(doc)
+
+    
     return {
         "msg": "OK",
         "embedding": embedding,
@@ -55,12 +79,16 @@ async def search_by_text(textp: TextP)-> dict:
     text = textp.text
     thresh = textp.thresh
     
-    print(text)
-    print(thresh)
-    
     embedding = await embedding_client.get_text_embedding(text)
     
     dists, ids = await search_client.search(embedding, thresh)
+    
+    collection = mydb["Top"]
+    documents = collection.find({'key': {'$in': ids}})
+    sorted_documents = sorted(documents, key=lambda doc: ids.index(doc['key']))
+
+    for doc in sorted_documents:
+        print(doc)
     
     return {
         "msg": "OK",
@@ -83,6 +111,15 @@ async def search_by_filter(file: UploadFile, text: Annotated[str, Form()], thres
     filter_embedding = await embedding_client.get_text_embedding(text)
     
     dists, ids = await search_client.search_with_filter(embedding, filter_embedding, thresh)
+    
+    collection = mydb["Top"]
+    documents = collection.find({'key': {'$in': ids}})
+    sorted_documents = sorted(documents, key=lambda doc: ids.index(doc['key']))
+
+    print("list", list(sorted_documents))
+    print("찾은 상품의 수", len(list(sorted_documents)))
+    # for doc in sorted_documents:
+    #     print(doc)
     
     return {
         "msg": "OK",


### PR DESCRIPTION
## Background 
- admin server에서 meta data를 관리했으니 customer server에서 ids(meta data에서는 key)를 통해서 meta data를 제공하도록 musinsa - Top collection과 연결을 시켜야합니다. 현재 생각으로는 상의, 하의를 db에 따로 넣는게 목적이긴한데 그렇게 되면 특정 collection을 선택해야하므로 성능이 물론 둘이 같이 있는 것보다는 빠르겠지만 사용자가 입력을 해야한다는 점이 좀 귀찮을 수가 있어서 그 부분은 어떻게 정책을 가질지 생각해야합니다.
---
## Works
- `server/customer/routes/proxy.py`
    - `.env`로 mongodb url과 database name을 관리했었기 때문에 config을 불러줍니다.
    - client와 musinsa db 객체를 불러오고 ids를 통해서 meta data를 출력합니다.
    - 현재는 return값을 수정하지는 않았습니다. 어떤 형식으로 할지는 추후 결정합니다.
      
## See Also & Error Log
- find, find_one 쿼리에 대한 시간을 비교했다. ids(meta data의 key)가 기본키가 되므로 쿼리를 날리는 기준으로 선택을 했다. find_one은 유사도순으로 정렬된 ids를 그대로 출력해준다. 하지만 collection 내부의 Key값을 전부 살펴본다. find는 find_one보다 속도가 매우 빠르지만 ids의 순서를 유지하기 위해서 `sorted_documents = sorted(documents, key=lambda doc: ids.index(doc['key']))` 라는 후속조치가 필요하다.  결과는 다음과 같다.
    - fine_one의 Execution time: 3.6651980876922607 seconds > 실제 검색 시 8.37s
    - find의 Execution time: 0.20023798942565918 seconds
    -  find + ids의 순서로 정렬한 것의 Execution time: 0.20313620567321777 seconds > 실제 검색 시 6.11s
    -  ids의 순서는 곧 유사도의 순위 >find_one이 find보다 18배나 느림 하지만 유사도 순으로 정렬되어있음.
    -  find 후 정렬을 사용하는 것이 find만 사용하는 것보다 0.0003s 차이지만 find_one보다는 압도적 성능을 지닌다.
    -  따라서 find 후에 sort하는게 같은 기능 대비 시간이 훨씬 적게 걸리는 것을 확인할 수 있었다.