### PR TITLE
Proxy

### DIFF
--- a/server/customer/routes/proxy.py
+++ b/server/customer/routes/proxy.py
@@ -97,8 +97,12 @@ async def search_by_filter(file: UploadFile, text: Annotated[str, Form()], thres
     
     text = await translate_client.translate(text)
     
-    embedding, filter_embedding = await asyncio.gather(embedding_client.get_image_embedding(rid), embedding_client.get_text_embedding(text))
+    # embedding, filter_embedding = await asyncio.gather(embedding_client.get_image_embedding(rid), embedding_client.get_text_embedding(text))
     
+    embedding = await embedding_client.get_image_embedding(rid)
+    
+    filter_embedding = await embedding_client.get_text_embedding(text)
+
     dists, ids = await search_client.search_with_filter(embedding, filter_embedding, thresh)
     
     documents = meta_client.find(ids)


### PR DESCRIPTION
## Background 
- 기존에 Input image에 대해서는 uuid를 사용해서 storage/queries에 저장을 했습니다. 그런데 같은 입력값에 대해서도 uuid가 부여되다보니 같은 이미지에 대해서 저장이 너무 빈번하게 돼서 hashlib을 사용해서 같은 입력에 대해서는 같은 값이 저장되도록 했습니다.
- 기존 `search-by-filter router` 에서는 image와 text embedding 각각 await를 했는데 `asyncio.gather`을 사용하는 것과 기존 코드를 비교해본 결과 `asyncio.gather` 사용했을 때 0.0x s 차이가 나므로 기존의 코드로 재변경했습니다.
---
## Works
- 
      
## See Also
- 